### PR TITLE
Updates android to use variables for framework versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -77,6 +77,7 @@
         </config-file>
         
         <framework src="com.google.gms:google-services:$GOOGLE_SERVICES_VERSION" />
+        <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION" />
         <framework src="com.twilio:voice-android:$VOICE_ANDROID_VERSION"/>
 
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java"

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
         <preference name="FCM_VERSION" default="10.2.1"/>
         <preference name="VOICE_ANDROID_VERSION" default="2.0.7"/>
 
-        <dependency id="phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
+        <dependency id="https://github.com/jbertucci-adig/phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <!-- [START fcm_listener] -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,7 +40,7 @@
         <preference name="FCM_VERSION" default="10.2.1"/>
         <preference name="VOICE_ANDROID_VERSION" default="2.0.7"/>
 
-        <dependency id="https://github.com/jbertucci-adig/phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
+        <dependency id="@mslobodan/phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <!-- [START fcm_listener] -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@
         </config-file>
 
         <preference name="GOOGLE_SERVICES_VERSION" default="3.0.0"/>
+        <preference name="FIREBASE_CORE_VERSION" default="16.0.7"/>
         <preference name="FCM_VERSION" default="10.2.1"/>
         <preference name="VOICE_ANDROID_VERSION" default="2.0.7"/>
 
@@ -76,7 +77,6 @@
         </config-file>
         
         <framework src="com.google.gms:google-services:$GOOGLE_SERVICES_VERSION" />
-        <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION" />
         <framework src="com.twilio:voice-android:$VOICE_ANDROID_VERSION"/>
 
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java"

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,7 +41,7 @@
         <preference name="FCM_VERSION" default="10.2.1"/>
         <preference name="VOICE_ANDROID_VERSION" default="2.0.7"/>
 
-        <dependency id="@mslobodan/phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
+        <dependency id="phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <!-- [START fcm_listener] -->

--- a/plugin.xml
+++ b/plugin.xml
@@ -36,7 +36,11 @@
             </feature>
         </config-file>
 
-        <dependency id="phonegap-plugin-push"/>
+        <preference name="GOOGLE_SERVICES_VERSION" default="3.0.0"/>
+        <preference name="FCM_VERSION" default="10.2.1"/>
+        <preference name="VOICE_ANDROID_VERSION" default="2.0.7"/>
+
+        <dependency id="phonegap-plugin-push"/> <!-- uses $FCM_VERSION for "firebase-messaging" -->
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <!-- [START fcm_listener] -->
@@ -71,9 +75,9 @@
             <string name="incoming_call_app_name" translatable="false">$INCOMING_CALL_APP_NAME</string>
         </config-file>
         
-        <framework src="com.google.gms:google-services:3.0.0" />
-        <framework src="com.google.firebase:firebase-messaging:10.2.1" />
-        <framework src="com.twilio:voice-android:2.0.7"/>
+        <framework src="com.google.gms:google-services:$GOOGLE_SERVICES_VERSION" />
+        <framework src="com.google.firebase:firebase-messaging:$FCM_VERSION" />
+        <framework src="com.twilio:voice-android:$VOICE_ANDROID_VERSION"/>
 
         <source-file src="src/android/com/phonegap/plugins/twiliovoice/TwilioVoicePlugin.java"
                 target-dir="src/com/phonegap/plugins/twiliovoice" />


### PR DESCRIPTION
This modifies the Android platform to allow variables for framework versions.

This is needed to allow our `config.xml` to align framework versions between different plugins and their dependencies.  Original hard-coded value where set as the defaults to keep backwards compatibility.  

New values can be used with `--variable` CLI parameter or simply added the variable to the `config.xml` and/or `package.json`.

**config.xml**
```
<plugin name="cordova-plugin-twiliovoicesdk" spec="https://github.com/altriadeveloper/cordova-plugin-twiliovoicesdk">
        <variable name="FCM_VERSION" value="17.0.+" />
</plugin>
```

**package.json**
```
"cordova-plugin-twiliovoicesdk": {
        "FCM_VERSION": "17.0.+"
}
```

All this is the setup to get Cordova to generate the proper versions in the `/platforms/android/project.properties` file.

Given the above example, this is what should be generated after doing `cordova platform add android`:
```
cordova.system.library.6=com.google.firebase:firebase-messaging:17.0.+
```

When running `cordova platform add android`, Cordova will read the `config.xml` and set the values in `package.json` and it will use the `package.json` value to generate the `project.properties` file.